### PR TITLE
Fix #103: Neon MPC fails at "/news/api/p"

### DIFF
--- a/org.dawnsci.marketplace.server/README.md
+++ b/org.dawnsci.marketplace.server/README.md
@@ -126,7 +126,7 @@ implemented.
 - [ ]	`/favorites/top/api/p` - Returns a server-defined number of top favorites
 - [ ]	`/popular/top/api/p` - Returns a server-defined number of most active results
 - [ ]	`/related/api/p` - Returns a server-defined number of recommendations based on a list of nodes provided as query parameter
-- [ ]	`/news/api/p` - Returns the news configuration details (news location/title...).
+- [x]	`/news/api/p` - Returns an empty news configuration
 
 There is one exception to adding /api/p at the end and that is for search
 results.

--- a/org.dawnsci.marketplace.server/src/main/java/org/dawnsci/marketplace/endpoints/MarketplaceEndpoint.java
+++ b/org.dawnsci.marketplace.server/src/main/java/org/dawnsci/marketplace/endpoints/MarketplaceEndpoint.java
@@ -52,6 +52,12 @@ public class MarketplaceEndpoint {
 	}
 
 	@GET
+	@Path("news/api/p")
+	public String getNews() throws Exception {
+		return serialize(marketplaceDAO.getNews());
+	}
+
+	@GET
 	@Path("catalogs/api/p")
 	public String getCatalogs() throws Exception {
 		return serialize(marketplaceDAO.getCatalogs());

--- a/org.dawnsci.marketplace.server/src/main/java/org/dawnsci/marketplace/services/MarketplaceDAO.java
+++ b/org.dawnsci.marketplace.server/src/main/java/org/dawnsci/marketplace/services/MarketplaceDAO.java
@@ -195,6 +195,16 @@ public class MarketplaceDAO {
 		return marketplace;
 	}
 
+	/**
+	 * Returns an empty news section for now.
+	 */
+	@Transactional
+	public Marketplace getNews() {
+		Marketplace marketplace = MarketplaceFactory.eINSTANCE.createMarketplace();
+		marketplace.setBaseUrl(marketplaceBaseUrl);
+		return marketplace;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Transactional
 	public Marketplace getFeatured() {


### PR DESCRIPTION
Task-Url: http://github.com/Itema-as/dawn-marketplace-server/issues/issue/103
